### PR TITLE
Avoid deleting WAL with inconsistent state

### DIFF
--- a/lm2.go
+++ b/lm2.go
@@ -757,7 +757,10 @@ func (c *Collection) Close() {
 	defer c.metaLock.Unlock()
 	c.f.Close()
 	c.wal.Close()
-	c.wal.Destroy()
+	if atomic.LoadUint32(&c.internalState) == 0 {
+		// Internal state is OK. Safe to delete WAL.
+		c.wal.Destroy()
+	}
 }
 
 // Version returns the last committed version.


### PR DESCRIPTION
Closes #32.