### PR TITLE
Fix records reappearing when deleted more than once

### DIFF
--- a/update.go
+++ b/update.go
@@ -299,6 +299,9 @@ KEYS_LOOP:
 		if rec.Key != key {
 			continue
 		}
+		if rec.Deleted != 0 {
+			continue
+		}
 		rec.Deleted = currentOffset
 		c.setDirty(rec.Offset, rec)
 		dirtyOffsets = append(dirtyOffsets, rec.Offset)


### PR DESCRIPTION
Already deleted records were getting their `Deleted` versions overwritten so they reappeared to stale cursors.