### PR TITLE
Make cache probability dependent on height

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -60,7 +60,7 @@ func (rc *recordCache) push(rec *record) {
 		return
 	}
 
-	if len(rc.cache) == rc.size && rand.Float32() >= cacheProb {
+	if len(rc.cache) == rc.size && rand.Float32() >= cacheProb/float32(len(rec.Next)) {
 		rc.lock.RUnlock()
 		return
 	}


### PR DESCRIPTION
Basically, the higher a node is on the skip list, the more likely it is to get cached.