### PR TITLE
Truncate to LastCommit on open

### DIFF
--- a/lm2.go
+++ b/lm2.go
@@ -249,6 +249,12 @@ func NewCollection(file string, cacheSize int) (*Collection, error) {
 		c.wal.Close()
 		return nil, err
 	}
+	err = c.f.Truncate(c.LastCommit)
+	if err != nil {
+		c.f.Close()
+		c.wal.Close()
+		return nil, err
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
This should've been done before. I think it *may* cause problems but I haven't run into any...